### PR TITLE
Remove ARC. It seems that if too many calls to setBadge are made very…

### DIFF
--- a/LSStatusBarClient.xm
+++ b/LSStatusBarClient.xm
@@ -63,10 +63,10 @@ extern "C" mach_port_t bootstrap_port;
 
 - (void) retrieveCurrentMessage
 {
-	_currentMessage = nil;
+	[_currentMessage release];
 	if(_isLocal)
 	{
-		_currentMessage = [[LSStatusBarServer sharedInstance] currentMessage];
+		_currentMessage = [[[LSStatusBarServer sharedInstance] currentMessage] retain];
 	}
 	else //if(LSBServerPort())
 	{
@@ -93,7 +93,7 @@ extern "C" mach_port_t bootstrap_port;
 		}
 
 		if (dmc)
-			_currentMessage = [dmc sendMessageAndReceiveReplyName:@"currentMessage" userInfo:nil];
+			_currentMessage = [[dmc sendMessageAndReceiveReplyName: @"currentMessage" userInfo: nil] retain];
 	}
 }
 
@@ -115,7 +115,8 @@ extern "C" mach_port_t bootstrap_port;
 	
 	NSMutableArray* processedKeys = [[_currentMessage objectForKey:@"keys"] mutableCopy];
 	
-	_titleStrings = [_currentMessage objectForKey:@"titleStrings"];
+	[_titleStrings release];
+	_titleStrings = [[_currentMessage objectForKey: @"titleStrings"] retain];
 	
 	int keyidx = 32; //(cfvers >= CF_70) ? 32 : 24;
 
@@ -205,6 +206,8 @@ extern "C" mach_port_t bootstrap_port;
 			}
 		}
 	}
+
+	[processedKeys release];
 	return YES;
 }
 
@@ -327,6 +330,8 @@ extern "C" mach_port_t bootstrap_port;
 			{
 				NSLog(@"[libstatusbar] CPDistributedMessagingCenter was not found when calling -[LSStatusBarClientsetProperties:forItem:].");
 			}
+
+			[dict release];
 		}
 	}
 }
@@ -343,5 +348,7 @@ extern "C" mach_port_t bootstrap_port;
 	{
 		[self setProperties:[messages objectForKey:key] forItem:key];
 	}
+
+	[messages release];
 }
 @end

--- a/LSStatusBarItem.mm
+++ b/LSStatusBarItem.mm
@@ -46,7 +46,7 @@ NSMutableDictionary* sbitems = nil;
 		if(!properties)
 			properties = [NSMutableDictionary new];
 		
-		_identifier = identifier;
+		_identifier = [identifier retain];
 		
 		[self _setProperties: properties];
 		
@@ -63,7 +63,10 @@ NSMutableDictionary* sbitems = nil;
 		idArray = [sbitems objectForKey:identifier];
 		if(!idArray)
 		{
-			[sbitems setObject:[NSMutableArray array] forKey:identifier];
+			// this creates a retain/release-less NSMutableArray
+			idArray = (NSMutableArray*) CFArrayCreateMutable(kCFAllocatorDefault, 0, NULL);
+			[sbitems setObject: idArray forKey: identifier];
+			CFRelease(idArray);
 		}
 	
 		if(idArray)
@@ -95,10 +98,12 @@ NSMutableDictionary* sbitems = nil;
 				[sbitems removeObjectForKey:_identifier];
 			}
 		}
+
+		[_identifier release];
+		[_properties release];
 	}
-#if !__has_feature(objc_arc)
+
 	[super dealloc];
-#endif
 }
 
 - (NSDictionary*) properties
@@ -110,7 +115,7 @@ NSMutableDictionary* sbitems = nil;
 {
 	if(dict == _properties)
 		return;
-	_properties = nil;
+	[_properties release];
 	
 	if(!dict)
 	{

--- a/LSStatusBarServer.mm
+++ b/LSStatusBarServer.mm
@@ -136,7 +136,7 @@ static void NoteExitKQueueCallback(
     NSNumber *              pidinfo
 )
 {
-    [[LSStatusBarServer sharedInstance] pidDidExit:pidinfo];
+    [[LSStatusBarServer sharedInstance] pidDidExit: [pidinfo autorelease]];
 }
 
 
@@ -145,7 +145,7 @@ void MonitorPID(NSNumber* pid)
     //FILE *                f;
     int                     kq;
     struct kevent           changes;
-    CFFileDescriptorContext context = { 0, (void *)CFBridgingRetain(pid), NULL, NULL, NULL };
+    CFFileDescriptorContext context = { 0, [pid retain], NULL, NULL, NULL };
     CFRunLoopSourceRef      rls;
 
     kq = kqueue();

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 ARCHS = armv7 armv7s arm64
 
-CFLAGS = -fobjc-arc
 TARGET=iphone:clang:8.1:7.0
 
 include $(THEOS)/makefiles/common.mk

--- a/UIStatusBarCustomItem.xm
+++ b/UIStatusBarCustomItem.xm
@@ -60,7 +60,8 @@
 -(void) setProperties:(NSDictionary*)properties
 {
 	__strong NSDictionary* &_properties(MSHookIvar<NSDictionary*>(self, "_properties"));
-	_properties = properties;
+	[_properties release];
+	_properties = [properties retain];
 }
 
 -(Class) viewClass
@@ -98,7 +99,8 @@
 -(void) setIndicatorName:(NSString*) name
 {
 	__strong NSString *&_indicatorName = MSHookIvar<NSString*>(self, "_indicatorName");
-	_indicatorName = name;
+	[_indicatorName release];
+	_indicatorName = [name retain];
 }
 
 %new


### PR DESCRIPTION
… quickly that libstatusbar (efrederickson) gets lost somewhere and does not remove views correctly.

This issue can be seen by using Cycript and OpenNotifier.

cycript -p SpringBoard

var sbac = objc_getClass("SBApplicationController")
var mApp = [[sbac sharedInstance] applicationWithDisplayIdentifier:@"com.apple.MobileSMS"]
var mIcon = [[objc_getClass("SBApplicationIcon") alloc] initWithApplication:mApp]
var c = 100
for(var i = 0; i < c; i++) {if (i == (c - 1)) {[mIcon setBadge:20];} else {[mIcon setBadge:i];}}

[mIcon setBadge:0]
