### PR TITLE
iOS 9

### DIFF
--- a/LSStatusBarClient.xm
+++ b/LSStatusBarClient.xm
@@ -124,7 +124,7 @@ extern "C" mach_port_t bootstrap_port;
 	[_titleStrings release];
 	_titleStrings = [[_currentMessage objectForKey: @"titleStrings"] retain];
 	
-	int keyidx = 32; //(cfvers >= CF_70) ? 32 : 24;
+	int keyidx = 64; //(cfvers >= CF_70) ? 32 : 24;
 
 	extern NSMutableArray* customItems[3];
 	


### PR DESCRIPTION
There are still some strange things going on (the icons sometimes disappear when I unlock my device, they don't show up in certain App store Apps (Waze) but work fine in other App store Apps (Alien Blue), but this is at least partially working.

And according to this, https://twitter.com/saurik/status/654198997024796672 and http://iphonedevwiki.net/index.php/Updating_extensions_for_iOS_9#Compilation_changes, you should compile with:

libstatusbar_LDFLAGS += -Wl,-segalign,4000 -lsubstrate -lrocketbootstrap
